### PR TITLE
fix: logger color reset issue

### DIFF
--- a/pkg/logger/color_logger.go
+++ b/pkg/logger/color_logger.go
@@ -28,9 +28,9 @@ func NewColorLogger(lg *log.Logger) *ColorLogger {
 }
 
 func (c *ColorLogger) Printcf(color Color, format string, args ...interface{}) {
-	c.Print(string(color) + fmt.Sprintf(format, args...) + string(ColorBlack))
+	c.Print(string(color) + fmt.Sprintf(format, args...) + string(ColorReset))
 }
 
 func (c *ColorLogger) Printc(color Color, s string) {
-	c.Print(string(color) + s + string(ColorBlack))
+	c.Print(string(color) + s + string(ColorReset))
 }


### PR DESCRIPTION
The logger was not resetting terminal colors after printing colorized log messages, causing subsequent terminal output to black color formatting.

change the color tag from `ColorBlack` to `ColorReset` to fix this issue.